### PR TITLE
Fixed bug

### DIFF
--- a/pkg/aliyun/client.go
+++ b/pkg/aliyun/client.go
@@ -82,8 +82,10 @@ func ECSClient(region string) (*ecs.Client, error) {
 			global.GetBasicOptionValue(global.AKSecret),
 		)
 		ecsClient, err = ecs.NewClientWithOptions(region, ecsConfig, credential)
-		logger.Println.Error("创建 ECS 客户端时报错，详细信息如下：")
-		logger.Println.Error(err.Error())
+		if err != nil {
+			logger.Println.Error("创建 ECS 客户端时报错，详细信息如下：")
+			logger.Println.Error(err.Error())
+		}
 	}
 	return ecsClient, err
 }


### PR DESCRIPTION
aliyun，当设置ak_token，并且创建esc客户端时，未判断error是否存在，导致程序panic

```
[ERROR] 2025-01-13 04:30:38 创建 ECS 客户端时报错，详细信息如下：
panic: runtime error: invalid memory address or nil pointer dereference
        panic: close of closed channel
[signal 0xc0000005 code=0x0 addr=0x18 pc=0x120dbac]

goroutine 1 [running]:
github.com/mattn/go-tty.(*TTY).close(0xc0000ac280)
        C:/Users/JBN/go/pkg/mod/github.com/mattn/go-tty@v0.0.3/tty_windows.go:331 +0x90
github.com/mattn/go-tty.(*TTY).Close(...)
        C:/Users/JBN/go/pkg/mod/github.com/mattn/go-tty@v0.0.3/tty.go:38
github.com/c-bata/go-prompt.(*WindowsParser).TearDown(0xc000342b47?)
        C:/Users/JBN/go/pkg/mod/github.com/c-bata/go-prompt@v0.2.6/input_windows.go:37 +0x16
github.com/c-bata/go-prompt.(*Prompt).tearDown(0xc0002843f0)
        C:/Users/JBN/go/pkg/mod/github.com/c-bata/go-prompt@v0.2.6/prompt.go:293 +0x2c
panic({0x13f6260?, 0x2476590?})
        C:/Users/JBN/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.2.windows-amd64/src/runtime/panic.go:785 +0x132
github.com/wgpsec/cloudsword/pkg/aliyun.ECSClient({0x160b2d5, 0xb})
        C:/JBNRZ/Documents/Github/cloudsword/pkg/aliyun/client.go:86 +0x3ec
github.com/wgpsec/cloudsword/pkg/aliyun.describeRegions()
        C:/JBNRZ/Documents/Github/cloudsword/pkg/aliyun/utilsECS.go:88 +0x117
github.com/wgpsec/cloudsword/pkg/aliyun.ECSListInstances()
        C:/JBNRZ/Documents/Github/cloudsword/pkg/aliyun/1301_ecs_list_instances.go:19 +0x25
github.com/wgpsec/cloudsword/pkg/aliyun.ListCloudAssets()
        C:/JBNRZ/Documents/Github/cloudsword/pkg/aliyun/1101_list_cloud_assets.go:7 +0x14
github.com/wgpsec/cloudsword/cmd.runModule({0x44d, {{0x1609d92, 0x9}, {0x16079aa, 0x6}}, {0x160fb76, 0x11}, {0x16092ff, 0x8}, {0x1629069, ...}, ...})
        C:/JBNRZ/Documents/Github/cloudsword/cmd/modules.go:86 +0x2aa
github.com/wgpsec/cloudsword/cmd.executor({0xc000594e0b?, 0x0?})
        C:/JBNRZ/Documents/Github/cloudsword/cmd/flag.go:136 +0x1658
github.com/c-bata/go-prompt.(*Prompt).Run(0xc0002843f0)
        C:/Users/JBN/go/pkg/mod/github.com/c-bata/go-prompt@v0.2.6/prompt.go:84 +0x71f
github.com/wgpsec/cloudsword/cmd.Run()
        C:/JBNRZ/Documents/Github/cloudsword/cmd/root.go:20 +0xf0
main.main()
        C:/JBNRZ/Documents/Github/cloudsword/main.go:6 +0xf
```


修补方式：添加对error的判断