### PR TITLE
Fixed bug

### DIFF
--- a/pkg/aliyun/1202_oss_search_objects.go
+++ b/pkg/aliyun/1202_oss_search_objects.go
@@ -118,7 +118,6 @@ func OSSSearchObjects() {
 								} else {
 									fmt.Printf("自定义元数据列表：%v\n", string(jsonBytes))
 								}
-								logger.Println.Error(err.Error())
 
 								fmt.Printf("访问地址：https://%v.oss-%v.aliyuncs.com/%v\n", bucketName, region, *file.Filename)
 							}

--- a/pkg/aliyun/1301_ecs_list_instances.go
+++ b/pkg/aliyun/1301_ecs_list_instances.go
@@ -123,7 +123,9 @@ func ECSListInstances() {
 					fmt.Printf("\n其他信息========\n")
 					fmt.Printf("删除保护：%v\n", i.DeletionProtection)
 					jsonBytes, err := json.Marshal(i.Tags.Tag)
-					logger.Println.Error(err.Error())
+					if err != nil {
+						logger.Println.Error(err.Error())
+					}
 					fmt.Printf("实例标签：%v\n", jsonBytes)
 					fmt.Printf("计费类型：%v\n", i.InstanceChargeType)
 					fmt.Printf("主机名称：%v\n", i.Hostname)

--- a/pkg/aliyun/client.go
+++ b/pkg/aliyun/client.go
@@ -82,8 +82,10 @@ func ECSClient(region string) (*ecs.Client, error) {
 			global.GetBasicOptionValue(global.AKSecret),
 		)
 		ecsClient, err = ecs.NewClientWithOptions(region, ecsConfig, credential)
-		logger.Println.Error("创建 ECS 客户端时报错，详细信息如下：")
-		logger.Println.Error(err.Error())
+		if err != nil {
+			logger.Println.Error("创建 ECS 客户端时报错，详细信息如下：")
+			logger.Println.Error(err.Error())
+		}
 	}
 	return ecsClient, err
 }

--- a/pkg/huaweiCloud/3201_obs_list_buckets.go
+++ b/pkg/huaweiCloud/3201_obs_list_buckets.go
@@ -23,9 +23,7 @@ func OBSListBuckets() {
 					fmt.Printf("区域：%v\n", b.Location)
 					fmt.Printf("访问地址：https://%v.obs.%v.myhuaweicloud.com\n", b.Name, b.Location)
 					creationDate := utils.FormatTime(&b.CreationDate)
-					if err == nil {
-						fmt.Printf("创建时间：%v\n", creationDate)
-					}
+					fmt.Printf("创建时间：%v\n", creationDate)
 					fmt.Println(strings.Repeat("=", 60))
 				}
 			}

--- a/utils/text.go
+++ b/utils/text.go
@@ -192,7 +192,9 @@ func SurveyConfirm(message string) bool {
 		Default: true,
 	}
 	err := survey.AskOne(prompt, &bool_)
-	logger.Println.Error(err.Error())
+	if err != nil {
+		logger.Println.Error(err.Error())
+	}
 	return bool_
 }
 


### PR DESCRIPTION
- Bug1: aliyun，当设置ak_token，并且创建esc客户端时，未判断error是否存在，导致程序panic

```
[ERROR] 2025-01-13 04:30:38 创建 ECS 客户端时报错，详细信息如下：
panic: runtime error: invalid memory address or nil pointer dereference
        panic: close of closed channel
[signal 0xc0000005 code=0x0 addr=0x18 pc=0x120dbac]

goroutine 1 [running]:
github.com/mattn/go-tty.(*TTY).close(0xc0000ac280)
        C:/Users/JBN/go/pkg/mod/github.com/mattn/go-tty@v0.0.3/tty_windows.go:331 +0x90
github.com/mattn/go-tty.(*TTY).Close(...)
        C:/Users/JBN/go/pkg/mod/github.com/mattn/go-tty@v0.0.3/tty.go:38
github.com/c-bata/go-prompt.(*WindowsParser).TearDown(0xc000342b47?)
        C:/Users/JBN/go/pkg/mod/github.com/c-bata/go-prompt@v0.2.6/input_windows.go:37 +0x16
github.com/c-bata/go-prompt.(*Prompt).tearDown(0xc0002843f0)
        C:/Users/JBN/go/pkg/mod/github.com/c-bata/go-prompt@v0.2.6/prompt.go:293 +0x2c
panic({0x13f6260?, 0x2476590?})
        C:/Users/JBN/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.2.windows-amd64/src/runtime/panic.go:785 +0x132
github.com/wgpsec/cloudsword/pkg/aliyun.ECSClient({0x160b2d5, 0xb})
        C:/JBNRZ/Documents/Github/cloudsword/pkg/aliyun/client.go:86 +0x3ec
github.com/wgpsec/cloudsword/pkg/aliyun.describeRegions()
        C:/JBNRZ/Documents/Github/cloudsword/pkg/aliyun/utilsECS.go:88 +0x117
github.com/wgpsec/cloudsword/pkg/aliyun.ECSListInstances()
        C:/JBNRZ/Documents/Github/cloudsword/pkg/aliyun/1301_ecs_list_instances.go:19 +0x25
github.com/wgpsec/cloudsword/pkg/aliyun.ListCloudAssets()
        C:/JBNRZ/Documents/Github/cloudsword/pkg/aliyun/1101_list_cloud_assets.go:7 +0x14
github.com/wgpsec/cloudsword/cmd.runModule({0x44d, {{0x1609d92, 0x9}, {0x16079aa, 0x6}}, {0x160fb76, 0x11}, {0x16092ff, 0x8}, {0x1629069, ...}, ...})
        C:/JBNRZ/Documents/Github/cloudsword/cmd/modules.go:86 +0x2aa
github.com/wgpsec/cloudsword/cmd.executor({0xc000594e0b?, 0x0?})
        C:/JBNRZ/Documents/Github/cloudsword/cmd/flag.go:136 +0x1658
github.com/c-bata/go-prompt.(*Prompt).Run(0xc0002843f0)
        C:/Users/JBN/go/pkg/mod/github.com/c-bata/go-prompt@v0.2.6/prompt.go:84 +0x71f
github.com/wgpsec/cloudsword/cmd.Run()
        C:/JBNRZ/Documents/Github/cloudsword/cmd/root.go:20 +0xf0
main.main()
        C:/JBNRZ/Documents/Github/cloudsword/main.go:6 +0xf
```

- Bug2: 1202_aliyun_oss_search_objects 当数据索引未启动时，询问用户是否继续时，未判断error，导致程序panic

```
[INFO] 2025-01-13 04:59:14 正在运行 1202_aliyun_oss_search_objects 模块。
? 查询 OSS 对象需要先创建数据索引，这需要一些时间，并且在查询过程中可能会产生一些费用，您要继续吗？ Yes
panic: runtime error: invalid memory address or nil pointer dereference
        panic: close of closed channel
[signal 0xc0000005 code=0x0 addr=0x18 pc=0xc7fd0e]

goroutine 1 [running]:
github.com/mattn/go-tty.(*TTY).close(0xc0005a6050)
        C:/Users/JBN/go/pkg/mod/github.com/mattn/go-tty@v0.0.3/tty_windows.go:331 +0x90
github.com/mattn/go-tty.(*TTY).Close(...)
        C:/Users/JBN/go/pkg/mod/github.com/mattn/go-tty@v0.0.3/tty.go:38
github.com/c-bata/go-prompt.(*WindowsParser).TearDown(0xc0004813f7?)
        C:/Users/JBN/go/pkg/mod/github.com/c-bata/go-prompt@v0.2.6/input_windows.go:37 +0x16
github.com/c-bata/go-prompt.(*Prompt).tearDown(0xc0002043f0)
        C:/Users/JBN/go/pkg/mod/github.com/c-bata/go-prompt@v0.2.6/prompt.go:293 +0x2c
panic({0x1546260?, 0x25c6590?})
        C:/Users/JBN/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.2.windows-amd64/src/runtime/panic.go:785 +0x132
github.com/wgpsec/cloudsword/utils.SurveyConfirm({0x1785b68, 0x8f})
        C:/JBNRZ/Documents/Github/cloudsword/utils/text.go:195 +0xee
github.com/wgpsec/cloudsword/pkg/aliyun.OSSSearchObjects()
        C:/JBNRZ/Documents/Github/cloudsword/pkg/aliyun/1202_oss_search_objects.go:27 +0x18f
github.com/wgpsec/cloudsword/cmd.runModule({0x4b2, {{0x1759d92, 0x9}, {0x17579aa, 0x6}}, {0x1760f3f, 0x12}, {0x17592ff, 0x8}, {0x17697bb, ...}, ...})
        C:/JBNRZ/Documents/Github/cloudsword/cmd/modules.go:90 +0x292
github.com/wgpsec/cloudsword/cmd.executor({0xc000691297?, 0x0?})
        C:/JBNRZ/Documents/Github/cloudsword/cmd/flag.go:136 +0x1658
github.com/c-bata/go-prompt.(*Prompt).Run(0xc0002043f0)
        C:/Users/JBN/go/pkg/mod/github.com/c-bata/go-prompt@v0.2.6/prompt.go:84 +0x71f
github.com/wgpsec/cloudsword/cmd.Run()
        C:/JBNRZ/Documents/Github/cloudsword/cmd/root.go:20 +0xf0
main.main()
        C:/JBNRZ/Documents/Github/cloudsword/main.go:6 +0xf
```

修补方式：添加对error的判断